### PR TITLE
feat: add NNewsAppService to export articles to NNews API

### DIFF
--- a/GitNews.Application/Startup.cs
+++ b/GitNews.Application/Startup.cs
@@ -7,6 +7,12 @@ using GitNews.Infra.Interfaces.AppServices;
 using GitNews.Infra.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NAuth.ACL;
+using NAuth.ACL.Interfaces;
+using NAuth.DTO;
+using NNews.ACL;
+using NNews.ACL.Interfaces;
+using NNews.DTO.Settings;
 
 namespace GitNews.Application;
 
@@ -34,6 +40,23 @@ public static class Startup
             opt.BaseUrl = settings.OpenAI.BaseUrl;
         });
 
+        services.Configure<NNewsSettings>(opt =>
+        {
+            opt.ApiUrl = settings.NNews.ApiUrl;
+            opt.Email = settings.NNews.Email;
+            opt.Password = settings.NNews.Password;
+        });
+
+        services.Configure<NNewsSetting>(opt =>
+        {
+            opt.ApiUrl = settings.NNews.ApiUrl;
+        });
+
+        services.Configure<NAuthSetting>(opt =>
+        {
+            opt.ApiUrl = settings.NNews.ApiUrl;
+        });
+
         // Logging
         services.AddLogging(builder => builder.AddConsole());
 
@@ -55,6 +78,9 @@ public static class Startup
         services.AddHttpClient<IDallEAppService, DallEAppService>();
         services.AddSingleton<IMediumAppService, MediumAppService>();
         services.AddSingleton<ILinkedInAppService, LinkedInAppService>();
+        services.AddHttpClient<IArticleClient, ArticleClient>();
+        services.AddHttpClient<IUserClient, UserClient>();
+        services.AddScoped<INNewsAppService, NNewsAppService>();
 
         // Domain Services
         services.AddScoped<IGitNewsProcessorService, GitNewsProcessorService>();

--- a/GitNews.Console/Program.cs
+++ b/GitNews.Console/Program.cs
@@ -79,6 +79,12 @@ class Program
                     return published ? 0 : 1;
                 }
 
+                if (command == "publish-nnews")
+                {
+                    var published = await processor.PublishOldestUnprocessedToNNewsAsync();
+                    return published ? 0 : 1;
+                }
+
                 var result = await processor.ProcessAllRepositoriesAsync();
                 await processor.GenerateMissingImagesAsync();
                 return result.HasErrors ? 1 : 0;
@@ -113,6 +119,8 @@ class Program
                 return "publish-medium";
             if (arg.Equals("--publish-linkedin", StringComparison.OrdinalIgnoreCase))
                 return "publish-linkedin";
+            if (arg.Equals("--publish-nnews", StringComparison.OrdinalIgnoreCase))
+                return "publish-nnews";
         }
         return null;
     }
@@ -132,6 +140,8 @@ class Program
                 case "--publish-medium":
                     break;
                 case "--publish-linkedin":
+                    break;
+                case "--publish-nnews":
                     break;
                 case "--output-dir":
                     if (i + 1 < args.Length) i++;
@@ -208,6 +218,7 @@ class Program
         System.Console.WriteLine("  --output-dir <dir>          Output directory for --export (default: ./output)");
         System.Console.WriteLine("  --publish-medium            Publish oldest unprocessed article to Medium via Chrome CDP");
         System.Console.WriteLine("  --publish-linkedin          Publish oldest unprocessed article to LinkedIn via Chrome CDP");
+        System.Console.WriteLine("  --publish-nnews             Publish oldest unprocessed article to NNews API");
         System.Console.WriteLine();
         System.Console.WriteLine("Options:");
         System.Console.WriteLine("  -o, --owner <owner>         GitHub account owner");

--- a/GitNews.Console/appsettings.example.json
+++ b/GitNews.Console/appsettings.example.json
@@ -13,5 +13,10 @@
   "Database": {
     "Provider": "PostgreSQL",
     "ConnectionString": "Host=localhost;Port=5432;Database=gitnews;Username=postgres;Password=postgres"
+  },
+  "NNews": {
+    "ApiUrl": "<your-nnews-api-url>",
+    "Email": "<your-nnews-email>",
+    "Password": "<your-nnews-password>"
   }
 }

--- a/GitNews.DTO/GitNewsSettings.cs
+++ b/GitNews.DTO/GitNewsSettings.cs
@@ -5,6 +5,7 @@ public class GitNewsSettings
     public GitHubSettings GitHub { get; set; } = new();
     public OpenAISettings OpenAI { get; set; } = new();
     public DatabaseSettings Database { get; set; } = new();
+    public NNewsSettings NNews { get; set; } = new();
 }
 
 public class GitHubSettings
@@ -29,6 +30,13 @@ public class DatabaseSettings
 {
     public string Provider { get; set; } = "PostgreSQL";
     public string ConnectionString { get; set; } = string.Empty;
+}
+
+public class NNewsSettings
+{
+    public string ApiUrl { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
 }
 
 public class WorkerSettings

--- a/GitNews.Domain/Interfaces/IGitNewsProcessorService.cs
+++ b/GitNews.Domain/Interfaces/IGitNewsProcessorService.cs
@@ -9,4 +9,5 @@ public interface IGitNewsProcessorService
     Task<bool> ExportOldestUnprocessedArticleAsync(string outputDir, CancellationToken cancellationToken = default);
     Task<bool> PublishOldestUnprocessedToMediumAsync(CancellationToken cancellationToken = default);
     Task<bool> PublishOldestUnprocessedToLinkedInAsync(CancellationToken cancellationToken = default);
+    Task<bool> PublishOldestUnprocessedToNNewsAsync(CancellationToken cancellationToken = default);
 }

--- a/GitNews.Domain/Services/GitNewsProcessorService.cs
+++ b/GitNews.Domain/Services/GitNewsProcessorService.cs
@@ -16,6 +16,7 @@ public class GitNewsProcessorService : IGitNewsProcessorService
     private readonly IDallEAppService _dallEService;
     private readonly IMediumAppService _mediumService;
     private readonly ILinkedInAppService _linkedInService;
+    private readonly INNewsAppService _nnewsService;
     private readonly IProcessedCommitRepository<ProcessedCommit> _commitRepo;
     private readonly IArticleRepository<Article> _articleRepo;
     private readonly GitHubSettings _githubSettings;
@@ -28,6 +29,7 @@ public class GitNewsProcessorService : IGitNewsProcessorService
         IDallEAppService dallEService,
         IMediumAppService mediumService,
         ILinkedInAppService linkedInService,
+        INNewsAppService nnewsService,
         IProcessedCommitRepository<ProcessedCommit> commitRepo,
         IArticleRepository<Article> articleRepo,
         IOptions<GitHubSettings> githubSettings,
@@ -39,6 +41,7 @@ public class GitNewsProcessorService : IGitNewsProcessorService
         _dallEService = dallEService;
         _mediumService = mediumService;
         _linkedInService = linkedInService;
+        _nnewsService = nnewsService;
         _commitRepo = commitRepo;
         _articleRepo = articleRepo;
         _githubSettings = githubSettings.Value;
@@ -399,6 +402,64 @@ public class GitNewsProcessorService : IGitNewsProcessorService
             cancellationToken);
 
         _logger.LogInformation("Article published on LinkedIn: {Url}", articleUrl);
+
+        // Mark as processed
+        article.IsProcessed = true;
+        await _articleRepo.UpdateAsync(article);
+        _logger.LogInformation("Article marked as processed: {Title}", article.Title);
+
+        return true;
+    }
+
+    public async Task<bool> PublishOldestUnprocessedToNNewsAsync(CancellationToken cancellationToken = default)
+    {
+        var article = await _articleRepo.FindOldestUnprocessedAsync();
+
+        if (article == null)
+        {
+            _logger.LogInformation("No unprocessed articles found to publish");
+            return false;
+        }
+
+        _logger.LogInformation("Publishing to NNews: {Title}", article.Title);
+
+        // Generate image if missing
+        byte[]? coverImage = null;
+        if (string.IsNullOrWhiteSpace(article.ImageBase64))
+        {
+            _logger.LogInformation("Article has no image. Generating via DALL-E...");
+            try
+            {
+                var imagePrompt = $"Create a modern, minimalist tech blog header image about: {article.Title}. Style: flat design, vibrant colors, no text.";
+                article.ImageBase64 = await _dallEService.GenerateImageBase64Async(imagePrompt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to generate image");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(article.ImageBase64))
+        {
+            coverImage = Convert.FromBase64String(article.ImageBase64);
+        }
+
+        // Parse tags
+        var tags = article.Tags
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Take(5)
+            .ToArray();
+
+        // Publish
+        var articleId = await _nnewsService.PublishArticleAsync(
+            article.Title,
+            article.Content,
+            article.Category,
+            tags,
+            coverImage,
+            cancellationToken);
+
+        _logger.LogInformation("Article published on NNews with ID: {ArticleId}", articleId);
 
         // Mark as processed
         article.IsProcessed = true;

--- a/GitNews.Infra.Interfaces/AppServices/INNewsAppService.cs
+++ b/GitNews.Infra.Interfaces/AppServices/INNewsAppService.cs
@@ -1,0 +1,6 @@
+namespace GitNews.Infra.Interfaces.AppServices;
+
+public interface INNewsAppService
+{
+    Task<string> PublishArticleAsync(string title, string markdownContent, string category, string[] tags, byte[]? coverImage = null, CancellationToken cancellationToken = default);
+}

--- a/GitNews.Infra/AppServices/NNewsAppService.cs
+++ b/GitNews.Infra/AppServices/NNewsAppService.cs
@@ -1,0 +1,83 @@
+using GitNews.DTO;
+using GitNews.Infra.Interfaces.AppServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NAuth.ACL.Interfaces;
+using NAuth.DTO;
+using NNews.ACL.Interfaces;
+using NNews.DTO;
+
+namespace GitNews.Infra.AppServices;
+
+public class NNewsAppService : INNewsAppService
+{
+    private readonly IArticleClient _articleClient;
+    private readonly IUserClient _userClient;
+    private readonly NNewsSettings _settings;
+    private readonly ILogger<NNewsAppService> _logger;
+    private string? _cachedToken;
+
+    public NNewsAppService(
+        IArticleClient articleClient,
+        IUserClient userClient,
+        IOptions<NNewsSettings> settings,
+        ILogger<NNewsAppService> logger)
+    {
+        _articleClient = articleClient;
+        _userClient = userClient;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    private async Task<string> GetTokenAsync()
+    {
+        if (!string.IsNullOrEmpty(_cachedToken))
+            return _cachedToken;
+
+        _logger.LogInformation("Authenticating with NAuth...");
+
+        var loginParam = new LoginParam
+        {
+            Email = _settings.Email,
+            Password = _settings.Password
+        };
+
+        var result = await _userClient.LoginWithEmailAsync(loginParam);
+        if (result == null || string.IsNullOrEmpty(result.Token))
+            throw new InvalidOperationException("Failed to authenticate with NAuth. Check your email and password settings.");
+
+        _cachedToken = result.Token;
+        _logger.LogInformation("Successfully authenticated with NAuth");
+
+        return _cachedToken;
+    }
+
+    public async Task<string> PublishArticleAsync(
+        string title,
+        string markdownContent,
+        string category,
+        string[] tags,
+        byte[]? coverImage = null,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetTokenAsync();
+
+        _logger.LogInformation("Publishing article to NNews: {Title}", title);
+
+        var articleInserted = new ArticleInsertedInfo
+        {
+            Title = title,
+            Content = markdownContent,
+            TagList = string.Join(",", tags),
+            Status = 1 // Published
+        };
+
+        var article = await _articleClient.CreateAsync(articleInserted, token);
+        if (article == null)
+            throw new InvalidOperationException("Failed to create article on NNews API.");
+
+        _logger.LogInformation("Article published on NNews with ID: {ArticleId}", article.ArticleId);
+
+        return article.ArticleId.ToString();
+    }
+}

--- a/GitNews.Infra/GitNews.Infra.csproj
+++ b/GitNews.Infra/GitNews.Infra.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.2.0" />
+    <PackageReference Include="NNews" Version="0.3.6" />
+    <PackageReference Include="NAuth" Version="0.4.3" />
   </ItemGroup>
 
 </Project>

--- a/GitNews.Worker/appsettings.example.json
+++ b/GitNews.Worker/appsettings.example.json
@@ -14,6 +14,11 @@
     "Provider": "PostgreSQL",
     "ConnectionString": "Host=localhost;Port=5432;Database=gitnews;Username=postgres;Password=postgres"
   },
+  "NNews": {
+    "ApiUrl": "<your-nnews-api-url>",
+    "Email": "<your-nnews-email>",
+    "Password": "<your-nnews-password>"
+  },
   "Worker": {
     "ScheduleTime": "19:00"
   },


### PR DESCRIPTION
Uses NNews NuGet package for article publishing and NAuth for JWT authentication. Adds INNewsAppService interface, NNewsAppService implementation, NNewsSettings configuration, DI registration, and --publish-nnews CLI command.

https://claude.ai/code/session_0146XHc1JaqBY9whEjCz6d2m